### PR TITLE
Allow container to shut down cleanly

### DIFF
--- a/.startup.sh
+++ b/.startup.sh
@@ -7,4 +7,5 @@ crontab /var/crons/crons
 cron -f &
 
 # php-fpm must be started in the foreground
-php-fpm
+# exec for signal handling
+exec php-fpm


### PR DESCRIPTION
Docker stops a container by sending SIGTERM to PID 1. In this case that's `.startup.sh`. But the script doesn't react to that, so after ten seconds it forces it with SIGKILL.

With `exec`, `php-fpm` becomes PID 1, which does shut down, removing the ten-second delay.

(This change would have to be applied to the other images too.)